### PR TITLE
Change python environment used in parallel call python

### DIFF
--- a/quetzal/os/parallel_call.py
+++ b/quetzal/os/parallel_call.py
@@ -1,9 +1,10 @@
 import json
 import os
 import shutil
+import subprocess
+import sys
 import time
 import uuid
-from subprocess import Popen
 import string
 from typing import Any
 
@@ -41,12 +42,12 @@ def parallel_call_jobs(jobs, mode='w', workers=1, sleep=1, raise_errors=False):
         with open(stdout_file, mode) as stdout:
             with open(stderr_file, mode) as stderr:
                 if type(arg) == tuple:
-                    command_list = ['python', file] + list(arg)
+                    command_list = [sys.executable, file] + list(arg)
                 else:
-                    command_list = ['python', file] + [arg]
+                    command_list = [sys.executable, file] + [arg]
                 # my_env = os.environ
                 # my_env["PYTHONPATH"] = os.pathsep.join(sys.path)[1:]
-                popens[i] = Popen(
+                popens[i] = subprocess.Popen(
                     command_list,
                     stdout=stdout,
                     stderr=stderr,
@@ -91,7 +92,7 @@ def parallel_call_notebooks(
         file = notebook.replace('.ipynb', '.py')
         files.append(file)
         if not os.path.exists(file):
-            os.system('jupyter nbconvert --to python %s' % notebook)
+            subprocess.run([sys.executable, '-m', 'jupyter', 'nbconvert', '--to', 'python', notebook])
         if not os.path.exists(file):  # jupyter nb convert failed, for instance, jupyter is not recognized
             convertNotebook(notebook, file)
         if freeze_support:
@@ -151,7 +152,7 @@ def parallel_call_notebook(
     return_jobs=False,
     raise_errors=False,
 ):
-    os.system('jupyter nbconvert --to python %s' % notebook)
+    subprocess.run([sys.executable, '-m', 'jupyter', 'nbconvert', '--to', 'python', notebook])
     file = notebook.replace('.ipynb', '.py')
     if not os.path.exists(file):  # jupyter nb convert failed, for instance, jupyter is not recognized
         convertNotebook(notebook, file)


### PR DESCRIPTION
We are running into bugs where we have multiple python environments available on a system, and the parallel call would pick up the wrong python environment - this is because system python is usually the one being used, and need to be specified in PATH. We would prefer to have parallel call python to be executed from the same environment that has imported and called quetzal, so we are proposing this change.

Please let us know if this would work for you. There are other options if you need to support running parallel call python to run on a different python environment, and if you'd need to support that functionality, I'd prefer that we explicitly pass the path of the python executable to parallel call python - instead of specifying in the PATH environment variable, so it is more clear which python is being used.